### PR TITLE
Require zlib explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "require": {
         "php": "^5.3.2 || ^7.0",
+        "ext-zlib": "*",
         "justinrainbow/json-schema": "^3.0 || ^4.0 || ^5.0",
         "composer/ca-bundle": "^1.0",
         "composer/semver": "^1.0",


### PR DESCRIPTION
```
[UnexpectedValueException]
unable to decompress gzipped phar archive "/var/www/html/application/vendor/npm-asset/jquery/4437b033cb619e45d3d03ef94554b01f.tgz" to temporary file, enable zlib extension in php.ini
```